### PR TITLE
fix: Add Vitest configuration for test infrastructure

### DIFF
--- a/src/app/core/guards/type-guards.spec.ts
+++ b/src/app/core/guards/type-guards.spec.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isMediaSourceType,
+  isMediaSource,
+  isStreamingPlatform,
+  isTwitchConfig,
+  isYouTubeConfig,
+  isInstagramConfig,
+  isDOMException,
+  isMediaCaptureErrorType,
+  isStreamingStatus,
+  validateMediaStreamConstraints,
+  checkBrowserSupport,
+} from './type-guards';
+import type { MediaSource } from '../models/media-stream.types';
+import type { TwitchConfig, YouTubeConfig, InstagramConfig } from '../models/platform-config.types';
+
+describe('Type Guards', () => {
+  describe('isMediaSourceType', () => {
+    it('should return true for valid media source types', () => {
+      expect(isMediaSourceType('camera')).toBe(true);
+      expect(isMediaSourceType('screen')).toBe(true);
+      expect(isMediaSourceType('audio')).toBe(true);
+      expect(isMediaSourceType('canvas')).toBe(true);
+    });
+
+    it('should return false for invalid types', () => {
+      expect(isMediaSourceType('invalid')).toBe(false);
+      expect(isMediaSourceType('video')).toBe(false);
+    });
+
+    it('should return false for null and undefined', () => {
+      expect(isMediaSourceType(null)).toBe(false);
+      expect(isMediaSourceType(undefined)).toBe(false);
+    });
+
+    it('should return false for non-string types', () => {
+      expect(isMediaSourceType(123)).toBe(false);
+      expect(isMediaSourceType({})).toBe(false);
+      expect(isMediaSourceType([])).toBe(false);
+      expect(isMediaSourceType(true)).toBe(false);
+    });
+  });
+
+  describe('isMediaSource', () => {
+    it('should return true for valid MediaSource object', () => {
+      const mockStream = new MediaStream();
+      const validSource: MediaSource = {
+        id: 'test-id' as MediaSource['id'],
+        type: 'camera',
+        stream: mockStream,
+        constraints: { video: true },
+        label: 'Test Camera',
+        capturedAt: new Date(),
+      };
+
+      expect(isMediaSource(validSource)).toBe(true);
+    });
+
+    it('should return false for null and undefined', () => {
+      expect(isMediaSource(null)).toBe(false);
+      expect(isMediaSource(undefined)).toBe(false);
+    });
+
+    it('should return false for non-object types', () => {
+      expect(isMediaSource('string')).toBe(false);
+      expect(isMediaSource(123)).toBe(false);
+      expect(isMediaSource(true)).toBe(false);
+    });
+
+    it('should return false for objects missing required fields', () => {
+      expect(isMediaSource({})).toBe(false);
+      expect(isMediaSource({ id: 'test' })).toBe(false);
+      expect(isMediaSource({ id: 'test', type: 'camera' })).toBe(false);
+    });
+
+    it('should return false when type is invalid', () => {
+      const mockStream = new MediaStream();
+      expect(
+        isMediaSource({
+          id: 'test-id',
+          type: 'invalid-type',
+          stream: mockStream,
+          label: 'Test',
+          capturedAt: new Date(),
+        })
+      ).toBe(false);
+    });
+
+    it('should return false when stream is not MediaStream', () => {
+      expect(
+        isMediaSource({
+          id: 'test-id',
+          type: 'camera',
+          stream: {},
+          label: 'Test',
+          capturedAt: new Date(),
+        })
+      ).toBe(false);
+    });
+
+    it('should return false when capturedAt is not Date', () => {
+      const mockStream = new MediaStream();
+      expect(
+        isMediaSource({
+          id: 'test-id',
+          type: 'camera',
+          stream: mockStream,
+          label: 'Test',
+          capturedAt: 'not-a-date',
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isStreamingPlatform', () => {
+    it('should return true for valid platforms', () => {
+      expect(isStreamingPlatform('twitch')).toBe(true);
+      expect(isStreamingPlatform('youtube')).toBe(true);
+      expect(isStreamingPlatform('youtube-shorts')).toBe(true);
+      expect(isStreamingPlatform('instagram')).toBe(true);
+      expect(isStreamingPlatform('tiktok')).toBe(true);
+    });
+
+    it('should return false for invalid platforms', () => {
+      expect(isStreamingPlatform('facebook')).toBe(false);
+      expect(isStreamingPlatform('twitter')).toBe(false);
+      expect(isStreamingPlatform('invalid')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isStreamingPlatform('')).toBe(false);
+    });
+
+    it('should return false for null and undefined', () => {
+      expect(isStreamingPlatform(null)).toBe(false);
+      expect(isStreamingPlatform(undefined)).toBe(false);
+    });
+
+    it('should return false for non-string types', () => {
+      expect(isStreamingPlatform(123)).toBe(false);
+      expect(isStreamingPlatform({})).toBe(false);
+      expect(isStreamingPlatform([])).toBe(false);
+    });
+  });
+
+  describe('isTwitchConfig', () => {
+    it('should return true for TwitchConfig', () => {
+      const config: TwitchConfig = {
+        platform: 'twitch',
+        enabled: true,
+        rtmpUrl: 'rtmp://live.twitch.tv/app' as TwitchConfig['rtmpUrl'],
+        streamKey: 'test-key' as TwitchConfig['streamKey'],
+        ingestServer: 'live-sfo.twitch.tv',
+      };
+
+      expect(isTwitchConfig(config)).toBe(true);
+    });
+
+    it('should return false for non-Twitch configs', () => {
+      const youtubeConfig: YouTubeConfig = {
+        platform: 'youtube',
+        enabled: true,
+        rtmpUrl: 'rtmp://a.rtmp.youtube.com/live2' as YouTubeConfig['rtmpUrl'],
+        streamKey: 'test-key' as YouTubeConfig['streamKey'],
+        broadcastId: 'test-broadcast',
+        privacyStatus: 'public',
+      };
+
+      expect(isTwitchConfig(youtubeConfig)).toBe(false);
+    });
+  });
+
+  describe('isYouTubeConfig', () => {
+    it('should return true for YouTubeConfig', () => {
+      const config: YouTubeConfig = {
+        platform: 'youtube',
+        enabled: true,
+        rtmpUrl: 'rtmp://a.rtmp.youtube.com/live2' as YouTubeConfig['rtmpUrl'],
+        streamKey: 'test-key' as YouTubeConfig['streamKey'],
+        broadcastId: 'test-broadcast',
+        privacyStatus: 'public',
+      };
+
+      expect(isYouTubeConfig(config)).toBe(true);
+    });
+
+    it('should return false for non-YouTube configs', () => {
+      const twitchConfig: TwitchConfig = {
+        platform: 'twitch',
+        enabled: true,
+        rtmpUrl: 'rtmp://live.twitch.tv/app' as TwitchConfig['rtmpUrl'],
+        streamKey: 'test-key' as TwitchConfig['streamKey'],
+        ingestServer: 'live-sfo.twitch.tv',
+      };
+
+      expect(isYouTubeConfig(twitchConfig)).toBe(false);
+    });
+  });
+
+  describe('isInstagramConfig', () => {
+    it('should return true for InstagramConfig', () => {
+      const config: InstagramConfig = {
+        platform: 'instagram',
+        enabled: true,
+        rtmpUrl: 'rtmp://live.instagram.com/rtmp' as InstagramConfig['rtmpUrl'],
+        streamKey: 'test-key' as InstagramConfig['streamKey'],
+        aspectRatio: 9 / 16,
+        isProfessionalAccount: true,
+      };
+
+      expect(isInstagramConfig(config)).toBe(true);
+    });
+
+    it('should return false for non-Instagram configs', () => {
+      const twitchConfig: TwitchConfig = {
+        platform: 'twitch',
+        enabled: true,
+        rtmpUrl: 'rtmp://live.twitch.tv/app' as TwitchConfig['rtmpUrl'],
+        streamKey: 'test-key' as TwitchConfig['streamKey'],
+        ingestServer: 'live-sfo.twitch.tv',
+      };
+
+      expect(isInstagramConfig(twitchConfig)).toBe(false);
+    });
+  });
+
+  describe('isDOMException', () => {
+    it('should return true for DOMException', () => {
+      const domException = new DOMException('Test error', 'NotAllowedError');
+      expect(isDOMException(domException)).toBe(true);
+    });
+
+    it('should return false for regular Error', () => {
+      const error = new Error('Test error');
+      expect(isDOMException(error)).toBe(false);
+    });
+
+    it('should return false for null and undefined', () => {
+      expect(isDOMException(null)).toBe(false);
+      expect(isDOMException(undefined)).toBe(false);
+    });
+
+    it('should return false for plain objects', () => {
+      expect(isDOMException({})).toBe(false);
+      expect(isDOMException({ message: 'test' })).toBe(false);
+    });
+  });
+
+  describe('isMediaCaptureErrorType', () => {
+    it('should return true for valid error types', () => {
+      expect(isMediaCaptureErrorType('NotAllowedError')).toBe(true);
+      expect(isMediaCaptureErrorType('NotFoundError')).toBe(true);
+      expect(isMediaCaptureErrorType('NotReadableError')).toBe(true);
+      expect(isMediaCaptureErrorType('OverconstrainedError')).toBe(true);
+      expect(isMediaCaptureErrorType('SecurityError')).toBe(true);
+      expect(isMediaCaptureErrorType('AbortError')).toBe(true);
+      expect(isMediaCaptureErrorType('TypeError')).toBe(true);
+      expect(isMediaCaptureErrorType('UnknownError')).toBe(true);
+    });
+
+    it('should return false for invalid error types', () => {
+      expect(isMediaCaptureErrorType('InvalidError')).toBe(false);
+      expect(isMediaCaptureErrorType('SomeOtherError')).toBe(false);
+    });
+
+    it('should return false for null and undefined', () => {
+      expect(isMediaCaptureErrorType(null)).toBe(false);
+      expect(isMediaCaptureErrorType(undefined)).toBe(false);
+    });
+
+    it('should return false for non-string types', () => {
+      expect(isMediaCaptureErrorType(123)).toBe(false);
+      expect(isMediaCaptureErrorType({})).toBe(false);
+    });
+  });
+
+  describe('isStreamingStatus', () => {
+    it('should return true for valid streaming statuses', () => {
+      expect(isStreamingStatus('initializing')).toBe(true);
+      expect(isStreamingStatus('connecting')).toBe(true);
+      expect(isStreamingStatus('live')).toBe(true);
+      expect(isStreamingStatus('paused')).toBe(true);
+      expect(isStreamingStatus('stopping')).toBe(true);
+      expect(isStreamingStatus('stopped')).toBe(true);
+      expect(isStreamingStatus('error')).toBe(true);
+    });
+
+    it('should return false for invalid statuses', () => {
+      expect(isStreamingStatus('invalid')).toBe(false);
+      expect(isStreamingStatus('pending')).toBe(false);
+      expect(isStreamingStatus('active')).toBe(false);
+    });
+
+    it('should return false for null and undefined', () => {
+      expect(isStreamingStatus(null)).toBe(false);
+      expect(isStreamingStatus(undefined)).toBe(false);
+    });
+
+    it('should return false for non-string types', () => {
+      expect(isStreamingStatus(123)).toBe(false);
+      expect(isStreamingStatus({})).toBe(false);
+    });
+  });
+
+  describe('validateMediaStreamConstraints', () => {
+    it('should validate correct constraints', () => {
+      const constraints: MediaStreamConstraints = {
+        video: {
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+          frameRate: { ideal: 30 },
+        },
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(true);
+      expect(result.errors.length).toBe(0);
+    });
+
+    it('should accept constraints with high frame rate', () => {
+      const constraints: MediaStreamConstraints = {
+        video: {
+          frameRate: { ideal: 60 },
+        },
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(true);
+      expect(result.errors.length).toBe(0);
+    });
+
+    it('should reject constraints with low frame rate', () => {
+      const constraints: MediaStreamConstraints = {
+        video: {
+          frameRate: { ideal: 15 }, // Below 20 FPS minimum
+        },
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'Frame rate should be at least 20 FPS for accessibility (sign language)'
+      );
+    });
+
+    it('should reject constraints with very low resolution', () => {
+      const constraints: MediaStreamConstraints = {
+        video: {
+          width: { ideal: 160 }, // Below 320px minimum
+        },
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Video width should be at least 320px');
+    });
+
+    it('should accept constraints with adequate resolution', () => {
+      const constraints: MediaStreamConstraints = {
+        video: {
+          width: { ideal: 640 },
+          height: { ideal: 480 },
+        },
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should handle constraints without video', () => {
+      const constraints: MediaStreamConstraints = {
+        audio: true,
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(true);
+      expect(result.errors.length).toBe(0);
+    });
+
+    it('should handle boolean video constraint', () => {
+      const constraints: MediaStreamConstraints = {
+        video: true,
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accumulate multiple errors', () => {
+      const constraints: MediaStreamConstraints = {
+        video: {
+          width: { ideal: 100 }, // Too low
+          frameRate: { ideal: 10 }, // Too low
+        },
+      };
+
+      const result = validateMediaStreamConstraints(constraints);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBe(2);
+    });
+  });
+
+  describe('checkBrowserSupport', () => {
+    it('should detect browser support', () => {
+      const result = checkBrowserSupport();
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('supported');
+      expect(result).toHaveProperty('missingFeatures');
+      expect(typeof result.supported).toBe('boolean');
+      expect(Array.isArray(result.missingFeatures)).toBe(true);
+    });
+
+    it('should return missingFeatures as an array', () => {
+      const result = checkBrowserSupport();
+      expect(Array.isArray(result.missingFeatures)).toBe(true);
+    });
+
+    it('should check for required APIs', () => {
+      const result = checkBrowserSupport();
+
+      // In a proper browser environment, these should exist
+      // In test environment, they might not
+      if (!result.supported) {
+        // If not supported, should list what's missing
+        expect(result.missingFeatures.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/app/core/guards/type-guards.ts
+++ b/src/app/core/guards/type-guards.ts
@@ -1,0 +1,186 @@
+import type {
+  MediaSource,
+  MediaSourceType,
+  MediaCaptureErrorType,
+} from '../models/media-stream.types';
+import type {
+  PlatformConfig,
+  TwitchConfig,
+  YouTubeConfig,
+  InstagramConfig,
+  StreamingPlatform,
+} from '../models/platform-config.types';
+import type { StreamingStatus } from '../models/streaming-session.types';
+
+/**
+ * Type guard: Check if value is a valid MediaSourceType
+ */
+export function isMediaSourceType(value: unknown): value is MediaSourceType {
+  return (
+    typeof value === 'string' &&
+    ['camera', 'screen', 'audio', 'canvas'].includes(value)
+  );
+}
+
+/**
+ * Type guard: Check if value is a valid MediaSource
+ */
+export function isMediaSource(value: unknown): value is MediaSource {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const source = value as Partial<MediaSource>;
+
+  return (
+    typeof source.id === 'string' &&
+    isMediaSourceType(source.type) &&
+    source.stream instanceof MediaStream &&
+    typeof source.label === 'string' &&
+    source.capturedAt instanceof Date
+  );
+}
+
+/**
+ * Type guard: Check if value is a valid StreamingPlatform
+ */
+export function isStreamingPlatform(value: unknown): value is StreamingPlatform {
+  return (
+    typeof value === 'string' &&
+    ['twitch', 'youtube', 'youtube-shorts', 'instagram', 'tiktok'].includes(value)
+  );
+}
+
+/**
+ * Type guard: Check if config is TwitchConfig
+ */
+export function isTwitchConfig(config: PlatformConfig): config is TwitchConfig {
+  return config.platform === 'twitch';
+}
+
+/**
+ * Type guard: Check if config is YouTubeConfig
+ */
+export function isYouTubeConfig(config: PlatformConfig): config is YouTubeConfig {
+  return config.platform === 'youtube';
+}
+
+/**
+ * Type guard: Check if config is InstagramConfig
+ */
+export function isInstagramConfig(config: PlatformConfig): config is InstagramConfig {
+  return config.platform === 'instagram';
+}
+
+/**
+ * Type guard: Check if error is DOMException
+ */
+export function isDOMException(error: unknown): error is DOMException {
+  return error instanceof DOMException;
+}
+
+/**
+ * Type guard: Check if value is valid MediaCaptureErrorType
+ */
+export function isMediaCaptureErrorType(value: unknown): value is MediaCaptureErrorType {
+  return (
+    typeof value === 'string' &&
+    [
+      'NotAllowedError',
+      'NotFoundError',
+      'NotReadableError',
+      'OverconstrainedError',
+      'SecurityError',
+      'AbortError',
+      'TypeError',
+      'UnknownError',
+    ].includes(value)
+  );
+}
+
+/**
+ * Type guard: Check if value is valid StreamingStatus
+ */
+export function isStreamingStatus(value: unknown): value is StreamingStatus {
+  return (
+    typeof value === 'string' &&
+    ['initializing', 'connecting', 'live', 'paused', 'stopping', 'stopped', 'error'].includes(
+      value
+    )
+  );
+}
+
+/**
+ * Runtime validator: Check if MediaStreamConstraints are valid
+ */
+export function validateMediaStreamConstraints(
+  constraints: MediaStreamConstraints
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (constraints.video && typeof constraints.video === 'object') {
+    const video = constraints.video as MediaTrackConstraints;
+
+    if (video.width && typeof video.width === 'object') {
+      const width = video.width as ConstrainULong;
+      if (typeof width !== 'number' && 'ideal' in width && width.ideal && width.ideal < 320) {
+        errors.push('Video width should be at least 320px');
+      }
+    }
+
+    if (video.frameRate && typeof video.frameRate === 'object') {
+      const frameRate = video.frameRate as ConstrainDouble;
+      if (typeof frameRate !== 'number' && 'ideal' in frameRate && frameRate.ideal && frameRate.ideal < 20) {
+        errors.push('Frame rate should be at least 20 FPS for accessibility (sign language)');
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Runtime validator: Check if browser supports required APIs
+ */
+export function checkBrowserSupport(): {
+  supported: boolean;
+  missingFeatures: string[];
+} {
+  const missingFeatures: string[] = [];
+
+  if (typeof navigator === 'undefined') {
+    missingFeatures.push('navigator');
+    return {
+      supported: false,
+      missingFeatures,
+    };
+  }
+
+  if (!navigator.mediaDevices) {
+    missingFeatures.push('navigator.mediaDevices');
+  }
+
+  if (!navigator.mediaDevices?.getUserMedia) {
+    missingFeatures.push('getUserMedia');
+  }
+
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    missingFeatures.push('getDisplayMedia');
+  }
+
+  if (typeof RTCPeerConnection === 'undefined') {
+    missingFeatures.push('RTCPeerConnection');
+  }
+
+  if (typeof window !== 'undefined' && !window.isSecureContext) {
+    missingFeatures.push('Secure context (HTTPS required)');
+  }
+
+  return {
+    supported: missingFeatures.length === 0,
+    missingFeatures,
+  };
+}

--- a/src/app/core/models/authentication.types.ts
+++ b/src/app/core/models/authentication.types.ts
@@ -1,0 +1,128 @@
+import type { StreamingPlatform } from './platform-config.types';
+
+/**
+ * Branded type for OAuth access tokens (prevents accidental logging)
+ */
+export type AccessToken = string & { readonly __brand: 'AccessToken' };
+
+/**
+ * Branded type for OAuth refresh tokens (prevents accidental logging)
+ */
+export type RefreshToken = string & { readonly __brand: 'RefreshToken' };
+
+/**
+ * OAuth 2.0 credentials
+ * WARNING: Should NEVER be stored in browser localStorage/sessionStorage
+ * Use HttpOnly cookies or backend storage only
+ */
+export interface PlatformCredentials {
+  /**
+   * OAuth access token
+   */
+  readonly accessToken: AccessToken;
+
+  /**
+   * OAuth refresh token
+   */
+  readonly refreshToken: RefreshToken;
+
+  /**
+   * Token expiration timestamp
+   */
+  readonly expiresAt: Date;
+
+  /**
+   * OAuth scopes granted
+   */
+  readonly scopes: readonly string[];
+
+  /**
+   * Token type (typically "Bearer")
+   */
+  readonly tokenType: string;
+}
+
+/**
+ * Authentication status for a platform
+ */
+export interface PlatformAuthStatus {
+  /**
+   * Platform identifier
+   */
+  readonly platform: StreamingPlatform;
+
+  /**
+   * Whether user is authenticated
+   */
+  readonly isAuthenticated: boolean;
+
+  /**
+   * Whether token is expired
+   */
+  readonly isExpired: boolean;
+
+  /**
+   * Granted scopes
+   */
+  readonly scopes: readonly string[];
+
+  /**
+   * Token expiration time (if authenticated)
+   */
+  readonly expiresAt?: Date;
+}
+
+/**
+ * OAuth authorization request parameters
+ */
+export interface OAuthAuthorizationRequest {
+  /**
+   * Platform to authorize
+   */
+  readonly platform: StreamingPlatform;
+
+  /**
+   * PKCE code challenge
+   */
+  readonly codeChallenge: string;
+
+  /**
+   * PKCE code challenge method (always S256)
+   */
+  readonly codeChallengeMethod: 'S256';
+
+  /**
+   * OAuth state parameter (CSRF protection)
+   */
+  readonly state: string;
+
+  /**
+   * Redirect URI
+   */
+  readonly redirectUri: string;
+}
+
+/**
+ * OAuth token response from backend
+ */
+export interface OAuthTokenResponse {
+  /**
+   * Platform that was authorized
+   */
+  readonly platform: StreamingPlatform;
+
+  /**
+   * Whether authorization was successful
+   */
+  readonly success: boolean;
+
+  /**
+   * Error message (if failed)
+   */
+  readonly error?: string;
+
+  /**
+   * Granted scopes
+   */
+  readonly scopes: readonly string[];
+}

--- a/src/app/core/models/index.ts
+++ b/src/app/core/models/index.ts
@@ -1,0 +1,100 @@
+// Media Stream Types
+export type {
+  MediaSourceId,
+  MediaSourceType,
+  MediaSource,
+  VideoConstraints,
+  AudioConstraints,
+  MediaDeviceInfo,
+  MediaCaptureErrorType,
+} from './media-stream.types';
+
+// Platform Configuration Types
+export type {
+  StreamingPlatform,
+  StreamKey,
+  RtmpUrl,
+  TwitchConfig,
+  YouTubeConfig,
+  YouTubeShortsConfig,
+  InstagramConfig,
+  TikTokConfig,
+  PlatformConfig,
+  PlatformConfigMap,
+  PlatformLimits,
+} from './platform-config.types';
+export { PLATFORM_LIMITS } from './platform-config.types';
+
+// Stream Settings Types
+export type {
+  VideoCodec,
+  AudioCodec,
+  VideoResolutionPreset,
+  VideoResolution,
+  FrameRate,
+  VideoEncoderSettings,
+  AudioEncoderSettings,
+  StreamSettings,
+  StreamQualityPreset,
+} from './stream-settings.types';
+export { VIDEO_RESOLUTIONS, STREAM_QUALITY_PRESETS } from './stream-settings.types';
+
+// WebRTC Gateway Types
+export type {
+  GatewayConnectionId,
+  ConnectionState,
+  IceConnectionState,
+  WebRTCConfiguration,
+  GatewayConnection,
+  ConnectionStats,
+  WebRTCErrorType,
+  WebRTCError,
+} from './webrtc-gateway.types';
+
+// Authentication Types
+export type {
+  AccessToken,
+  RefreshToken,
+  PlatformCredentials,
+  PlatformAuthStatus,
+  OAuthAuthorizationRequest,
+  OAuthTokenResponse,
+} from './authentication.types';
+
+// Streaming Session Types
+export type {
+  SessionId,
+  StreamingStatus,
+  ActivePlatformStream,
+  StreamingSession,
+  StreamingStats,
+  StreamingError,
+} from './streaming-session.types';
+
+// Scene Composition Types
+export type {
+  SceneId,
+  SceneSourceId,
+  SceneComposition,
+  SceneSource,
+  SceneTransform,
+  SceneBorder,
+  SceneCrop,
+  TextOverlay,
+  SceneTemplate,
+} from './scene-composition.types';
+
+// Type Guards
+export {
+  isMediaSourceType,
+  isMediaSource,
+  isStreamingPlatform,
+  isTwitchConfig,
+  isYouTubeConfig,
+  isInstagramConfig,
+  isDOMException,
+  isMediaCaptureErrorType,
+  isStreamingStatus,
+  validateMediaStreamConstraints,
+  checkBrowserSupport,
+} from '../guards/type-guards';

--- a/src/app/core/models/media-stream.types.ts
+++ b/src/app/core/models/media-stream.types.ts
@@ -1,0 +1,153 @@
+/**
+ * Unique identifier for a media source
+ */
+export type MediaSourceId = string & { readonly __brand: 'MediaSourceId' };
+
+/**
+ * Type of media source
+ */
+export type MediaSourceType = 'camera' | 'screen' | 'audio' | 'canvas';
+
+/**
+ * Represents a captured media source (webcam, screen, microphone, or canvas)
+ */
+export interface MediaSource {
+  /**
+   * Unique identifier for this media source
+   */
+  readonly id: MediaSourceId;
+
+  /**
+   * Type of media source
+   */
+  readonly type: MediaSourceType;
+
+  /**
+   * Native browser MediaStream object
+   */
+  readonly stream: MediaStream;
+
+  /**
+   * Constraints used to capture this stream
+   */
+  readonly constraints: MediaStreamConstraints;
+
+  /**
+   * Human-readable label for this source (e.g., "Front Camera", "Screen Share")
+   */
+  readonly label: string;
+
+  /**
+   * Timestamp when this source was captured
+   */
+  readonly capturedAt: Date;
+}
+
+/**
+ * Video capture constraints with ideal/min/max ranges
+ */
+export interface VideoConstraints {
+  /**
+   * Ideal video width in pixels (e.g., 1920)
+   */
+  readonly width: number;
+
+  /**
+   * Ideal video height in pixels (e.g., 1080)
+   */
+  readonly height: number;
+
+  /**
+   * Ideal frame rate (e.g., 30, 60)
+   * Minimum 20 FPS recommended for accessibility (sign language - EN 301 549)
+   */
+  readonly frameRate: number;
+
+  /**
+   * Camera facing mode (for mobile devices)
+   */
+  readonly facingMode?: 'user' | 'environment';
+
+  /**
+   * Specific device ID to use (from enumerateDevices)
+   */
+  readonly deviceId?: string;
+
+  /**
+   * Aspect ratio constraint (e.g., 16/9, 9/16 for vertical)
+   */
+  readonly aspectRatio?: number;
+}
+
+/**
+ * Audio capture constraints
+ */
+export interface AudioConstraints {
+  /**
+   * Enable acoustic echo cancellation (recommended: true)
+   */
+  readonly echoCancellation: boolean;
+
+  /**
+   * Enable noise suppression (recommended: true)
+   */
+  readonly noiseSuppression: boolean;
+
+  /**
+   * Enable automatic gain control (recommended: true)
+   */
+  readonly autoGainControl: boolean;
+
+  /**
+   * Specific audio device ID (from enumerateDevices)
+   */
+  readonly deviceId?: string;
+
+  /**
+   * Sample rate in Hz (typical: 48000)
+   */
+  readonly sampleRate?: number;
+
+  /**
+   * Number of audio channels (1 = mono, 2 = stereo)
+   */
+  readonly channelCount?: number;
+}
+
+/**
+ * Device information from navigator.mediaDevices.enumerateDevices()
+ */
+export interface MediaDeviceInfo {
+  /**
+   * Unique device identifier
+   */
+  readonly deviceId: string;
+
+  /**
+   * Type of device
+   */
+  readonly kind: 'videoinput' | 'audioinput' | 'audiooutput';
+
+  /**
+   * Human-readable device label (may be empty if permissions not granted)
+   */
+  readonly label: string;
+
+  /**
+   * Device group ID (devices from same physical device share this)
+   */
+  readonly groupId: string;
+}
+
+/**
+ * Error types that can occur during media capture
+ */
+export type MediaCaptureErrorType =
+  | 'NotAllowedError'        // User denied permission
+  | 'NotFoundError'          // No device found
+  | 'NotReadableError'       // Device in use by another application
+  | 'OverconstrainedError'   // Constraints cannot be satisfied
+  | 'SecurityError'          // Access blocked (HTTPS required)
+  | 'AbortError'             // Capture aborted by user
+  | 'TypeError'              // Invalid constraints
+  | 'UnknownError';          // Other errors

--- a/src/app/core/models/platform-config.types.ts
+++ b/src/app/core/models/platform-config.types.ts
@@ -1,0 +1,258 @@
+/**
+ * Supported streaming platforms
+ */
+export type StreamingPlatform =
+  | 'twitch'
+  | 'youtube'
+  | 'youtube-shorts'
+  | 'instagram'
+  | 'tiktok';
+
+/**
+ * Branded type for stream keys (prevents accidental logging)
+ */
+export type StreamKey = string & { readonly __brand: 'StreamKey' };
+
+/**
+ * Branded type for RTMP URLs
+ */
+export type RtmpUrl = string & { readonly __brand: 'RtmpUrl' };
+
+/**
+ * Base platform configuration (common fields)
+ */
+interface BasePlatformConfig {
+  /**
+   * Platform identifier
+   */
+  readonly platform: StreamingPlatform;
+
+  /**
+   * Whether streaming to this platform is enabled
+   */
+  readonly enabled: boolean;
+
+  /**
+   * RTMP ingest URL for this platform
+   */
+  readonly rtmpUrl: RtmpUrl;
+
+  /**
+   * Stream key (should be stored securely, never in client storage)
+   */
+  readonly streamKey: StreamKey;
+}
+
+/**
+ * Twitch-specific configuration
+ */
+export interface TwitchConfig extends BasePlatformConfig {
+  readonly platform: 'twitch';
+
+  /**
+   * Twitch ingest server (e.g., "live-sfo.twitch.tv")
+   */
+  readonly ingestServer: string;
+
+  /**
+   * Stream title (max 140 characters)
+   */
+  readonly title?: string;
+
+  /**
+   * Game/category ID
+   */
+  readonly categoryId?: string;
+}
+
+/**
+ * YouTube Live configuration
+ */
+export interface YouTubeConfig extends BasePlatformConfig {
+  readonly platform: 'youtube';
+
+  /**
+   * YouTube broadcast ID
+   */
+  readonly broadcastId: string;
+
+  /**
+   * Stream title (max 100 characters)
+   */
+  readonly title?: string;
+
+  /**
+   * Stream description
+   */
+  readonly description?: string;
+
+  /**
+   * Privacy status
+   */
+  readonly privacyStatus: 'public' | 'unlisted' | 'private';
+}
+
+/**
+ * YouTube Shorts configuration (vertical video)
+ * Note: As of 2024, YouTube Shorts does NOT support live streaming
+ */
+export interface YouTubeShortsConfig extends BasePlatformConfig {
+  readonly platform: 'youtube-shorts';
+
+  /**
+   * Must be vertical aspect ratio (9:16)
+   */
+  readonly aspectRatio: 0.5625;
+
+  /**
+   * Note: This will upload as regular video with #Shorts tag
+   */
+  readonly note: 'Not true live streaming - vertical format only';
+}
+
+/**
+ * Instagram Live configuration
+ */
+export interface InstagramConfig extends BasePlatformConfig {
+  readonly platform: 'instagram';
+
+  /**
+   * Must be vertical aspect ratio (9:16) - REQUIRED by Instagram
+   */
+  readonly aspectRatio: 0.5625;
+
+  /**
+   * Professional account required
+   */
+  readonly isProfessionalAccount: boolean;
+}
+
+/**
+ * TikTok Live configuration
+ * WARNING: No official API as of 2024
+ */
+export interface TikTokConfig extends BasePlatformConfig {
+  readonly platform: 'tiktok';
+
+  /**
+   * Warning about unofficial status
+   */
+  readonly warning: 'No official TikTok live streaming API - unsupported';
+
+  /**
+   * Minimum follower requirement
+   */
+  readonly minimumFollowers: 1000;
+}
+
+/**
+ * Discriminated union of all platform configurations
+ */
+export type PlatformConfig =
+  | TwitchConfig
+  | YouTubeConfig
+  | YouTubeShortsConfig
+  | InstagramConfig
+  | TikTokConfig;
+
+/**
+ * Map of platform to its configuration
+ */
+export type PlatformConfigMap = Partial<Record<StreamingPlatform, PlatformConfig>>;
+
+/**
+ * Platform-specific validation rules
+ */
+export interface PlatformLimits {
+  /**
+   * Maximum stream title length
+   */
+  readonly maxTitleLength: number;
+
+  /**
+   * Maximum stream description length
+   */
+  readonly maxDescriptionLength?: number;
+
+  /**
+   * Required aspect ratio (null = any)
+   */
+  readonly requiredAspectRatio: number | null;
+
+  /**
+   * Maximum video bitrate in Kbps
+   */
+  readonly maxVideoBitrate: number;
+
+  /**
+   * Maximum audio bitrate in Kbps
+   */
+  readonly maxAudioBitrate: number;
+
+  /**
+   * Supported video codecs
+   */
+  readonly supportedVideoCodecs: readonly string[];
+
+  /**
+   * Supported audio codecs
+   */
+  readonly supportedAudioCodecs: readonly string[];
+
+  /**
+   * Maximum stream duration in seconds (null = unlimited)
+   */
+  readonly maxDuration: number | null;
+}
+
+/**
+ * Platform limits for all platforms
+ */
+export const PLATFORM_LIMITS: Record<StreamingPlatform, PlatformLimits> = {
+  twitch: {
+    maxTitleLength: 140,
+    requiredAspectRatio: null,
+    maxVideoBitrate: 6000,
+    maxAudioBitrate: 160,
+    supportedVideoCodecs: ['h264'],
+    supportedAudioCodecs: ['aac'],
+    maxDuration: 86400, // 24 hours
+  },
+  youtube: {
+    maxTitleLength: 100,
+    maxDescriptionLength: 5000,
+    requiredAspectRatio: null,
+    maxVideoBitrate: 20000,
+    maxAudioBitrate: 256,
+    supportedVideoCodecs: ['h264', 'h265'],
+    supportedAudioCodecs: ['aac'],
+    maxDuration: 86400, // 24 hours
+  },
+  'youtube-shorts': {
+    maxTitleLength: 100,
+    requiredAspectRatio: 0.5625,
+    maxVideoBitrate: 10000,
+    maxAudioBitrate: 128,
+    supportedVideoCodecs: ['h264'],
+    supportedAudioCodecs: ['aac'],
+    maxDuration: 60, // 60 seconds
+  },
+  instagram: {
+    maxTitleLength: 2200,
+    requiredAspectRatio: 0.5625,
+    maxVideoBitrate: 4000,
+    maxAudioBitrate: 128,
+    supportedVideoCodecs: ['h264'],
+    supportedAudioCodecs: ['aac'],
+    maxDuration: null,
+  },
+  tiktok: {
+    maxTitleLength: 150,
+    requiredAspectRatio: 0.5625,
+    maxVideoBitrate: 4000,
+    maxAudioBitrate: 128,
+    supportedVideoCodecs: ['h264'],
+    supportedAudioCodecs: ['aac'],
+    maxDuration: null,
+  },
+} as const;

--- a/src/app/core/models/scene-composition.types.ts
+++ b/src/app/core/models/scene-composition.types.ts
@@ -1,0 +1,282 @@
+import type { MediaSourceId } from './media-stream.types';
+
+/**
+ * Unique scene identifier
+ */
+export type SceneId = string & { readonly __brand: 'SceneId' };
+
+/**
+ * Unique scene source identifier
+ */
+export type SceneSourceId = string & { readonly __brand: 'SceneSourceId' };
+
+/**
+ * Scene composition (canvas-based layout)
+ */
+export interface SceneComposition {
+  /**
+   * Unique scene identifier
+   */
+  readonly id: SceneId;
+
+  /**
+   * Human-readable scene name
+   */
+  readonly name: string;
+
+  /**
+   * Canvas width in pixels
+   */
+  readonly width: number;
+
+  /**
+   * Canvas height in pixels
+   */
+  readonly height: number;
+
+  /**
+   * Scene background color (CSS color string)
+   */
+  readonly backgroundColor: string;
+
+  /**
+   * Media sources in this scene
+   */
+  readonly sources: readonly SceneSource[];
+
+  /**
+   * Whether this scene is currently active
+   */
+  readonly isActive: boolean;
+
+  /**
+   * When scene was created
+   */
+  readonly createdAt: Date;
+
+  /**
+   * When scene was last modified
+   */
+  readonly modifiedAt: Date;
+}
+
+/**
+ * Source within a scene (positioned media element)
+ */
+export interface SceneSource {
+  /**
+   * Unique identifier for this scene source
+   */
+  readonly id: SceneSourceId;
+
+  /**
+   * Reference to MediaSource being displayed
+   */
+  readonly sourceId: MediaSourceId;
+
+  /**
+   * X position in pixels (top-left corner)
+   */
+  readonly x: number;
+
+  /**
+   * Y position in pixels (top-left corner)
+   */
+  readonly y: number;
+
+  /**
+   * Width in pixels
+   */
+  readonly width: number;
+
+  /**
+   * Height in pixels
+   */
+  readonly height: number;
+
+  /**
+   * Z-index for layering (higher = on top)
+   */
+  readonly zIndex: number;
+
+  /**
+   * Whether source is visible
+   */
+  readonly visible: boolean;
+
+  /**
+   * Transform applied to source
+   */
+  readonly transform?: SceneTransform;
+
+  /**
+   * Border settings
+   */
+  readonly border?: SceneBorder;
+
+  /**
+   * Crop settings
+   */
+  readonly crop?: SceneCrop;
+}
+
+/**
+ * Transform applied to a scene source
+ */
+export interface SceneTransform {
+  /**
+   * Rotation in degrees (0-360)
+   */
+  readonly rotation: number;
+
+  /**
+   * Horizontal scale (1.0 = 100%)
+   */
+  readonly scaleX: number;
+
+  /**
+   * Vertical scale (1.0 = 100%)
+   */
+  readonly scaleY: number;
+
+  /**
+   * Opacity (0.0 = transparent, 1.0 = opaque)
+   */
+  readonly opacity: number;
+}
+
+/**
+ * Border settings for scene source
+ */
+export interface SceneBorder {
+  /**
+   * Border width in pixels
+   */
+  readonly width: number;
+
+  /**
+   * Border color (CSS color string)
+   */
+  readonly color: string;
+
+  /**
+   * Border style
+   */
+  readonly style: 'solid' | 'dashed' | 'dotted';
+
+  /**
+   * Border radius in pixels
+   */
+  readonly radius: number;
+}
+
+/**
+ * Crop settings for scene source
+ */
+export interface SceneCrop {
+  /**
+   * Top crop in pixels
+   */
+  readonly top: number;
+
+  /**
+   * Right crop in pixels
+   */
+  readonly right: number;
+
+  /**
+   * Bottom crop in pixels
+   */
+  readonly bottom: number;
+
+  /**
+   * Left crop in pixels
+   */
+  readonly left: number;
+}
+
+/**
+ * Text overlay in scene
+ */
+export interface TextOverlay {
+  /**
+   * Unique identifier
+   */
+  readonly id: SceneSourceId;
+
+  /**
+   * Text content (sanitized, no HTML)
+   */
+  readonly text: string;
+
+  /**
+   * Font family
+   */
+  readonly fontFamily: string;
+
+  /**
+   * Font size in pixels
+   */
+  readonly fontSize: number;
+
+  /**
+   * Font weight
+   */
+  readonly fontWeight: 'normal' | 'bold' | number;
+
+  /**
+   * Text color (CSS color)
+   */
+  readonly color: string;
+
+  /**
+   * Background color (CSS color)
+   */
+  readonly backgroundColor?: string;
+
+  /**
+   * Text alignment
+   */
+  readonly textAlign: 'left' | 'center' | 'right';
+
+  /**
+   * Position
+   */
+  readonly x: number;
+  readonly y: number;
+
+  /**
+   * Z-index
+   */
+  readonly zIndex: number;
+
+  /**
+   * Visibility
+   */
+  readonly visible: boolean;
+}
+
+/**
+ * Scene template/preset
+ */
+export interface SceneTemplate {
+  /**
+   * Template name
+   */
+  readonly name: string;
+
+  /**
+   * Template description
+   */
+  readonly description: string;
+
+  /**
+   * Thumbnail URL
+   */
+  readonly thumbnailUrl: string;
+
+  /**
+   * Factory function to create scene from template
+   */
+  readonly createScene: (sources: MediaSourceId[]) => SceneComposition;
+}

--- a/src/app/core/models/stream-settings.types.ts
+++ b/src/app/core/models/stream-settings.types.ts
@@ -1,0 +1,213 @@
+/**
+ * Video codec types
+ */
+export type VideoCodec = 'h264' | 'h265' | 'vp8' | 'vp9' | 'av1';
+
+/**
+ * Audio codec types
+ */
+export type AudioCodec = 'aac' | 'opus' | 'mp3';
+
+/**
+ * Video resolution presets
+ */
+export type VideoResolutionPreset =
+  | '480p'   // 854x480
+  | '720p'   // 1280x720
+  | '1080p'  // 1920x1080
+  | '1440p'  // 2560x1440
+  | '4k';    // 3840x2160
+
+/**
+ * Video resolution dimensions
+ */
+export interface VideoResolution {
+  readonly width: number;
+  readonly height: number;
+  readonly label: VideoResolutionPreset | 'custom';
+}
+
+/**
+ * Resolution preset mappings
+ */
+export const VIDEO_RESOLUTIONS: Record<VideoResolutionPreset, VideoResolution> = {
+  '480p': { width: 854, height: 480, label: '480p' },
+  '720p': { width: 1280, height: 720, label: '720p' },
+  '1080p': { width: 1920, height: 1080, label: '1080p' },
+  '1440p': { width: 2560, height: 1440, label: '1440p' },
+  '4k': { width: 3840, height: 2160, label: '4k' },
+} as const;
+
+/**
+ * Frame rate presets
+ */
+export type FrameRate = 20 | 24 | 30 | 60;
+
+/**
+ * Video encoder settings
+ */
+export interface VideoEncoderSettings {
+  /**
+   * Video codec
+   */
+  readonly codec: VideoCodec;
+
+  /**
+   * Video resolution
+   */
+  readonly resolution: VideoResolution;
+
+  /**
+   * Frame rate in FPS (min 20 for accessibility)
+   */
+  readonly frameRate: FrameRate;
+
+  /**
+   * Video bitrate in Kbps
+   */
+  readonly bitrate: number;
+
+  /**
+   * Keyframe interval in seconds (typical: 2)
+   */
+  readonly keyframeInterval: number;
+
+  /**
+   * Hardware acceleration enabled
+   */
+  readonly hardwareAcceleration: boolean;
+
+  /**
+   * Encoding profile (baseline, main, high)
+   */
+  readonly profile?: 'baseline' | 'main' | 'high';
+}
+
+/**
+ * Audio encoder settings
+ */
+export interface AudioEncoderSettings {
+  /**
+   * Audio codec
+   */
+  readonly codec: AudioCodec;
+
+  /**
+   * Audio bitrate in Kbps
+   */
+  readonly bitrate: number;
+
+  /**
+   * Sample rate in Hz (typical: 48000)
+   */
+  readonly sampleRate: number;
+
+  /**
+   * Number of channels (1 = mono, 2 = stereo)
+   */
+  readonly channels: 1 | 2;
+}
+
+/**
+ * Complete stream settings
+ */
+export interface StreamSettings {
+  /**
+   * Video encoder settings
+   */
+  readonly video: VideoEncoderSettings;
+
+  /**
+   * Audio encoder settings
+   */
+  readonly audio: AudioEncoderSettings;
+
+  /**
+   * Whether to enable low-latency mode
+   */
+  readonly lowLatencyMode: boolean;
+}
+
+/**
+ * Preset stream quality profiles
+ */
+export type StreamQualityPreset = 'low' | 'medium' | 'high' | 'ultra' | 'custom';
+
+/**
+ * Predefined quality presets
+ */
+export const STREAM_QUALITY_PRESETS: Record<StreamQualityPreset, StreamSettings | null> = {
+  low: {
+    video: {
+      codec: 'h264',
+      resolution: VIDEO_RESOLUTIONS['480p'],
+      frameRate: 30,
+      bitrate: 1500,
+      keyframeInterval: 2,
+      hardwareAcceleration: true,
+      profile: 'baseline',
+    },
+    audio: {
+      codec: 'aac',
+      bitrate: 96,
+      sampleRate: 48000,
+      channels: 2,
+    },
+    lowLatencyMode: false,
+  },
+  medium: {
+    video: {
+      codec: 'h264',
+      resolution: VIDEO_RESOLUTIONS['720p'],
+      frameRate: 30,
+      bitrate: 3000,
+      keyframeInterval: 2,
+      hardwareAcceleration: true,
+      profile: 'main',
+    },
+    audio: {
+      codec: 'aac',
+      bitrate: 128,
+      sampleRate: 48000,
+      channels: 2,
+    },
+    lowLatencyMode: false,
+  },
+  high: {
+    video: {
+      codec: 'h264',
+      resolution: VIDEO_RESOLUTIONS['1080p'],
+      frameRate: 30,
+      bitrate: 6000,
+      keyframeInterval: 2,
+      hardwareAcceleration: true,
+      profile: 'high',
+    },
+    audio: {
+      codec: 'aac',
+      bitrate: 160,
+      sampleRate: 48000,
+      channels: 2,
+    },
+    lowLatencyMode: false,
+  },
+  ultra: {
+    video: {
+      codec: 'h264',
+      resolution: VIDEO_RESOLUTIONS['1080p'],
+      frameRate: 60,
+      bitrate: 9000,
+      keyframeInterval: 2,
+      hardwareAcceleration: true,
+      profile: 'high',
+    },
+    audio: {
+      codec: 'aac',
+      bitrate: 192,
+      sampleRate: 48000,
+      channels: 2,
+    },
+    lowLatencyMode: true,
+  },
+  custom: null, // User-defined settings
+} as const;

--- a/src/app/core/models/streaming-session.types.ts
+++ b/src/app/core/models/streaming-session.types.ts
@@ -1,0 +1,194 @@
+import type { MediaSourceId } from './media-stream.types';
+import type { StreamingPlatform } from './platform-config.types';
+
+/**
+ * Unique session identifier
+ */
+export type SessionId = string & { readonly __brand: 'SessionId' };
+
+/**
+ * Streaming session status
+ */
+export type StreamingStatus =
+  | 'initializing'  // Setting up connections
+  | 'connecting'    // Establishing WebRTC/RTMP
+  | 'live'          // Actively streaming
+  | 'paused'        // Stream paused
+  | 'stopping'      // Gracefully stopping
+  | 'stopped'       // Stopped cleanly
+  | 'error';        // Error occurred
+
+/**
+ * Active stream to a specific platform
+ */
+export interface ActivePlatformStream {
+  /**
+   * Platform identifier
+   */
+  readonly platform: StreamingPlatform;
+
+  /**
+   * Stream status for this platform
+   */
+  readonly status: StreamingStatus;
+
+  /**
+   * When streaming to this platform started
+   */
+  readonly startedAt: Date;
+
+  /**
+   * Current video bitrate in Kbps
+   */
+  readonly videoBitrate: number;
+
+  /**
+   * Current audio bitrate in Kbps
+   */
+  readonly audioBitrate: number;
+
+  /**
+   * Error information (if status is 'error')
+   */
+  readonly error?: StreamingError;
+
+  /**
+   * Whether this platform stream can be retried
+   */
+  readonly retryable: boolean;
+}
+
+/**
+ * Streaming session (represents one broadcast session)
+ */
+export interface StreamingSession {
+  /**
+   * Unique session identifier
+   */
+  readonly id: SessionId;
+
+  /**
+   * When session was created
+   */
+  readonly createdAt: Date;
+
+  /**
+   * When streaming started (null if not started)
+   */
+  readonly startedAt: Date | null;
+
+  /**
+   * When streaming ended (null if still active)
+   */
+  readonly endedAt: Date | null;
+
+  /**
+   * Overall session status
+   */
+  readonly status: StreamingStatus;
+
+  /**
+   * Active platform streams
+   */
+  readonly platforms: readonly ActivePlatformStream[];
+
+  /**
+   * Media sources being used in this session
+   */
+  readonly sources: readonly MediaSourceId[];
+
+  /**
+   * Real-time streaming statistics
+   */
+  readonly stats: StreamingStats;
+}
+
+/**
+ * Real-time streaming statistics
+ */
+export interface StreamingStats {
+  /**
+   * Current video bitrate in Kbps
+   */
+  readonly videoBitrate: number;
+
+  /**
+   * Current audio bitrate in Kbps
+   */
+  readonly audioBitrate: number;
+
+  /**
+   * Current frames per second
+   */
+  readonly fps: number;
+
+  /**
+   * Number of dropped frames
+   */
+  readonly droppedFrames: number;
+
+  /**
+   * Total frames sent
+   */
+  readonly totalFrames: number;
+
+  /**
+   * Percentage of frames dropped (0-100)
+   */
+  readonly dropRate: number;
+
+  /**
+   * CPU usage percentage (0-100)
+   */
+  readonly cpuUsage: number;
+
+  /**
+   * Network latency in milliseconds
+   */
+  readonly networkLatency: number;
+
+  /**
+   * Total bytes sent
+   */
+  readonly bytesSent: number;
+
+  /**
+   * Timestamp of last stats update
+   */
+  readonly timestamp: Date;
+}
+
+/**
+ * Streaming error
+ */
+export interface StreamingError {
+  /**
+   * Error code
+   */
+  readonly code: string;
+
+  /**
+   * Human-readable error message
+   */
+  readonly message: string;
+
+  /**
+   * When error occurred
+   */
+  readonly timestamp: Date;
+
+  /**
+   * Whether error is recoverable
+   */
+  readonly recoverable: boolean;
+
+  /**
+   * Platform that experienced error (if platform-specific)
+   */
+  readonly platform?: StreamingPlatform;
+
+  /**
+   * Suggested action for user
+   */
+  readonly suggestedAction?: string;
+}

--- a/src/app/core/models/webrtc-gateway.types.ts
+++ b/src/app/core/models/webrtc-gateway.types.ts
@@ -1,0 +1,189 @@
+/**
+ * Unique identifier for a gateway connection
+ */
+export type GatewayConnectionId = string & { readonly __brand: 'GatewayConnectionId' };
+
+/**
+ * WebRTC peer connection state (from RTCPeerConnectionState)
+ */
+export type ConnectionState =
+  | 'new'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'failed'
+  | 'closed';
+
+/**
+ * ICE connection state
+ */
+export type IceConnectionState =
+  | 'new'
+  | 'checking'
+  | 'connected'
+  | 'completed'
+  | 'failed'
+  | 'disconnected'
+  | 'closed';
+
+/**
+ * WebRTC configuration for peer connection
+ */
+export interface WebRTCConfiguration {
+  /**
+   * ICE servers (STUN/TURN)
+   */
+  readonly iceServers: readonly RTCIceServer[];
+
+  /**
+   * ICE transport policy
+   */
+  readonly iceTransportPolicy: RTCIceTransportPolicy;
+
+  /**
+   * Bundle policy (max-bundle recommended for performance)
+   */
+  readonly bundlePolicy: RTCBundlePolicy;
+
+  /**
+   * RTP/RTCP multiplexing policy
+   */
+  readonly rtcpMuxPolicy: RTCRtcpMuxPolicy;
+}
+
+/**
+ * WebRTC gateway connection
+ */
+export interface GatewayConnection {
+  /**
+   * Unique connection identifier
+   */
+  readonly id: GatewayConnectionId;
+
+  /**
+   * Native RTCPeerConnection object
+   */
+  readonly peerConnection: RTCPeerConnection;
+
+  /**
+   * Current connection state
+   */
+  readonly state: ConnectionState;
+
+  /**
+   * ICE connection state
+   */
+  readonly iceConnectionState: IceConnectionState;
+
+  /**
+   * Gateway server URL
+   */
+  readonly gatewayUrl: string;
+
+  /**
+   * Configuration used for this connection
+   */
+  readonly configuration: WebRTCConfiguration;
+
+  /**
+   * When connection was established
+   */
+  readonly connectedAt?: Date;
+
+  /**
+   * Media tracks being sent
+   */
+  readonly tracks: readonly MediaStreamTrack[];
+}
+
+/**
+ * WebRTC connection statistics
+ */
+export interface ConnectionStats {
+  /**
+   * Bytes sent
+   */
+  readonly bytesSent: number;
+
+  /**
+   * Bytes received
+   */
+  readonly bytesReceived: number;
+
+  /**
+   * Packets sent
+   */
+  readonly packetsSent: number;
+
+  /**
+   * Packets lost
+   */
+  readonly packetsLost: number;
+
+  /**
+   * Current round-trip time in ms
+   */
+  readonly roundTripTime: number;
+
+  /**
+   * Available outgoing bitrate in bps
+   */
+  readonly availableOutgoingBitrate: number;
+
+  /**
+   * Current outgoing bitrate in bps
+   */
+  readonly currentOutgoingBitrate: number;
+
+  /**
+   * Jitter in seconds
+   */
+  readonly jitter: number;
+
+  /**
+   * Timestamp of stats collection
+   */
+  readonly timestamp: Date;
+}
+
+/**
+ * WebRTC error types
+ */
+export type WebRTCErrorType =
+  | 'ConnectionFailed'
+  | 'IceGatheringFailed'
+  | 'SignalingError'
+  | 'MediaError'
+  | 'NetworkError'
+  | 'TimeoutError'
+  | 'UnknownError';
+
+/**
+ * WebRTC connection error
+ */
+export interface WebRTCError {
+  /**
+   * Error type
+   */
+  readonly type: WebRTCErrorType;
+
+  /**
+   * Human-readable message
+   */
+  readonly message: string;
+
+  /**
+   * Connection state when error occurred
+   */
+  readonly connectionState: ConnectionState;
+
+  /**
+   * Whether connection can be retried
+   */
+  readonly recoverable: boolean;
+
+  /**
+   * Original error (if available)
+   */
+  readonly originalError?: Error;
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,84 @@
+// Global test setup file for Vitest
+
+// This file will be executed before running tests
+// Use it to setup global test utilities, mocks, and custom matchers
+
+// Initialize Angular test environment
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+// Initialize Angular testing environment (zoneless)
+import { provideZonelessChangeDetection } from '@angular/core';
+
+// Only initialize once
+try {
+  getTestBed().initTestEnvironment(
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting(),
+    {
+      errorOnUnknownElements: true,
+      errorOnUnknownProperties: true,
+    }
+  );
+} catch (error) {
+  // Already initialized, ignore
+}
+
+// Register custom matchers
+import './testing/matchers';
+
+// Mock MediaStream API for testing (not available in jsdom)
+class MockMediaStream implements MediaStream {
+  id = crypto.randomUUID();
+  active = true;
+
+  private tracks: MediaStreamTrack[] = [];
+
+  getTracks(): MediaStreamTrack[] {
+    return this.tracks;
+  }
+
+  getVideoTracks(): MediaStreamTrack[] {
+    return this.tracks.filter((t) => t.kind === 'video');
+  }
+
+  getAudioTracks(): MediaStreamTrack[] {
+    return this.tracks.filter((t) => t.kind === 'audio');
+  }
+
+  getTrackById(trackId: string): MediaStreamTrack | null {
+    return this.tracks.find((t) => t.id === trackId) ?? null;
+  }
+
+  addTrack(track: MediaStreamTrack): void {
+    this.tracks.push(track);
+  }
+
+  removeTrack(track: MediaStreamTrack): void {
+    this.tracks = this.tracks.filter((t) => t !== track);
+  }
+
+  clone(): MediaStream {
+    return new MockMediaStream();
+  }
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  dispatchEvent(): boolean {
+    return true;
+  }
+
+  onaddtrack = null;
+  onremovetrack = null;
+}
+
+// Make MediaStream available globally in test environment
+if (typeof global !== 'undefined') {
+  (global as typeof globalThis).MediaStream = MockMediaStream as unknown as typeof MediaStream;
+}
+if (typeof window !== 'undefined') {
+  (window as typeof globalThis).MediaStream = MockMediaStream as unknown as typeof MediaStream;
+}

--- a/src/testing/matchers.ts
+++ b/src/testing/matchers.ts
@@ -1,0 +1,12 @@
+// Custom Vitest matchers for Stream Buddy
+// Add custom matchers here if needed in the future
+
+import { expect } from 'vitest';
+
+// Placeholder for custom matchers
+// Example:
+// expect.extend({
+//   toBeValidStreamConfig(received) {
+//     // Custom matcher logic
+//   }
+// });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,28 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+import analog from '@analogjs/vite-plugin-angular';
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  plugins: [analog()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['src/test-setup.ts'],
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'src/test-setup.ts',
+        '**/*.config.ts',
+        '**/*.d.ts',
+        '**/index.ts',
+      ],
+    },
+  },
+  define: {
+    'import.meta.vitest': undefined,
+  },
+}));


### PR DESCRIPTION
## Summary
- Created vitest.config.mts for proper ESM module support with @analogjs/vite-plugin-angular
- Added src/testing/matchers.ts for custom test matchers
- Fixed test execution blocking issue that was preventing all Phase 1 development
- All 47 tests now passing successfully

## Root Cause
The project was missing a vitest.config file, which caused test execution to fail. Additionally, the config needed to be a .mts file to properly support ESM imports required by @analogjs/vite-plugin-angular.

## Test Results
```
Test Files  2 passed (2)
Tests  47 passed (47)
```

## Impact
This fix unblocks:
- Security audits for Issues #1 and #2
- Code reviews requiring passing tests
- Continued development on all Phase 1 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)